### PR TITLE
fix query selectors for google organic results

### DIFF
--- a/src/modules/google.js
+++ b/src/modules/google.js
@@ -57,11 +57,11 @@ class GoogleScraper extends Scraper {
             organic_results.forEach((el) => {
 
                 let serp_obj = {
-                    link: _attr(el, '.r a', 'href'),
-                    title: _text(el, '.r a h3'),
-                    snippet: _text(el, 'span.st'),
-                    visible_link: _text(el, '.r cite'),
-                    date: _text(el, 'span.f'),
+                    link: _attr(el, '.rc a', 'href'),
+                    title: _text(el, '.rc a h3'),
+                    snippet: _text(el, '.rc > div:nth-child(2) span span'),
+                    visible_link: _text(el, '.rc cite'),
+                    date: _text(el, '.rc > div:nth-child(2) span.f'),
                 };
 
                 if (serp_obj.date) {


### PR DESCRIPTION
The problem was reported in this issue https://github.com/NikolaiT/se-scraper/issues/81.  
After checking html code of google's results I have noticed that query selector need to be adjusted to new html code provided by google.